### PR TITLE
Remove Merged Tag Condition

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func nextTag(latest string, level Level) (string, error) {
 }
 
 func tags(ctx context.Context) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "git", "tag", "--merged")
+	cmd := exec.CommandContext(ctx, "git", "tag")
 	b, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to run `git tag`: %v", err)


### PR DESCRIPTION
removing merged condition on tag acquisition such that running bumper on merged pr will work properly